### PR TITLE
cabi: use unsafe.Pointer as underlying slice type for allocations

### DIFF
--- a/cabi/realloc.go
+++ b/cabi/realloc.go
@@ -40,13 +40,13 @@ func alloc(size, align uintptr) unsafe.Pointer {
 		s := make([]uint16, min(size/align, 1))
 		return unsafe.Pointer(unsafe.SliceData(s))
 	case 4:
-		s := make([]uint32, min(size/align, 1))
+		s := make([]alloc32, min(size/align, 1))
 		return unsafe.Pointer(unsafe.SliceData(s))
 	case 8:
-		s := make([]uint64, min(size/align, 1))
+		s := make([]alloc64, min(size/align, 1))
 		return unsafe.Pointer(unsafe.SliceData(s))
 	default:
-		s := make([][16]uint8, min(size/align, 1))
+		s := make([]alloc128, min(size/align, 1))
 		return unsafe.Pointer(unsafe.SliceData(s))
 	}
 }

--- a/cabi/types.go
+++ b/cabi/types.go
@@ -1,0 +1,18 @@
+package cabi
+
+import "unsafe"
+
+func init() {
+	var a32 alloc32
+	if unsafe.Sizeof(a32) != 4 {
+		panic("sizeof alloc32 != 4")
+	}
+	var a64 alloc64
+	if unsafe.Sizeof(a64) != 8 {
+		panic("sizeof alloc64 != 8")
+	}
+	var a128 alloc128
+	if unsafe.Sizeof(a128) != 16 {
+		panic("sizeof alloc128 != 16")
+	}
+}

--- a/cabi/types32.go
+++ b/cabi/types32.go
@@ -1,0 +1,24 @@
+//go:build wasm32 || tinygo.wasm
+
+package cabi
+
+import "unsafe"
+
+type alloc32 = unsafe.Pointer
+type alloc64 = [2]unsafe.Pointer
+type alloc128 = [4]unsafe.Pointer
+
+func init() {
+	var a32 alloc32
+	if unsafe.Sizeof(a32) != 4 {
+		panic("sizeof alloc32 != 4")
+	}
+	var a64 alloc64
+	if unsafe.Sizeof(a64) != 8 {
+		panic("sizeof alloc64 != 8")
+	}
+	var a128 alloc128
+	if unsafe.Sizeof(a128) != 16 {
+		panic("sizeof alloc128 != 16")
+	}
+}

--- a/cabi/types32.go
+++ b/cabi/types32.go
@@ -7,18 +7,3 @@ import "unsafe"
 type alloc32 = unsafe.Pointer
 type alloc64 = [2]unsafe.Pointer
 type alloc128 = [4]unsafe.Pointer
-
-func init() {
-	var a32 alloc32
-	if unsafe.Sizeof(a32) != 4 {
-		panic("sizeof alloc32 != 4")
-	}
-	var a64 alloc64
-	if unsafe.Sizeof(a64) != 8 {
-		panic("sizeof alloc64 != 8")
-	}
-	var a128 alloc128
-	if unsafe.Sizeof(a128) != 16 {
-		panic("sizeof alloc128 != 16")
-	}
-}

--- a/cabi/types64.go
+++ b/cabi/types64.go
@@ -1,0 +1,11 @@
+//go:build !wasm32 && !tinygo.wasm
+
+package cabi
+
+import (
+	"unsafe"
+)
+
+type alloc32 = uint32
+type alloc64 = unsafe.Pointer
+type alloc128 = [2]unsafe.Pointer


### PR DESCRIPTION
**Do not merge**