### PR TITLE
wit/bindgen: propagate type direction to generated Go functions

### DIFF
--- a/testdata/issues/issue165.wit
+++ b/testdata/issues/issue165.wit
@@ -15,4 +15,6 @@ world resources {
 	}
 
 	export big-record: func(r: big);
+
+	export maybe-with-z: func(a: option<borrow<z>>);
 }

--- a/testdata/issues/issue165.wit
+++ b/testdata/issues/issue165.wit
@@ -1,0 +1,18 @@
+// https://github.com/bytecodealliance/wasm-tools-go/issues/165
+package issues:issue165;
+
+interface types {
+	resource z {
+		constructor(a: f64);
+	}
+}
+
+world resources {
+	use types.{z};
+
+	record big {
+		x1: borrow<z>,
+	}
+
+	export big-record: func(r: big);
+}

--- a/testdata/issues/issue165.wit.json
+++ b/testdata/issues/issue165.wit.json
@@ -28,6 +28,19 @@
             ],
             "results": []
           }
+        },
+        "maybe-with-z": {
+          "function": {
+            "name": "maybe-with-z",
+            "kind": "freestanding",
+            "params": [
+              {
+                "name": "a",
+                "type": 4
+              }
+            ],
+            "results": []
+          }
         }
       },
       "package": 0
@@ -53,7 +66,7 @@
           ],
           "results": [
             {
-              "type": 4
+              "type": 5
             }
           ]
         }
@@ -102,6 +115,13 @@
       "owner": {
         "world": 0
       }
+    },
+    {
+      "name": null,
+      "kind": {
+        "option": 2
+      },
+      "owner": null
     },
     {
       "name": null,

--- a/testdata/issues/issue165.wit.json
+++ b/testdata/issues/issue165.wit.json
@@ -1,0 +1,130 @@
+{
+  "worlds": [
+    {
+      "name": "resources",
+      "imports": {
+        "interface-0": {
+          "interface": {
+            "id": 0
+          }
+        },
+        "z": {
+          "type": 1
+        },
+        "big": {
+          "type": 3
+        }
+      },
+      "exports": {
+        "big-record": {
+          "function": {
+            "name": "big-record",
+            "kind": "freestanding",
+            "params": [
+              {
+                "name": "r",
+                "type": 3
+              }
+            ],
+            "results": []
+          }
+        }
+      },
+      "package": 0
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "types",
+      "types": {
+        "z": 0
+      },
+      "functions": {
+        "[constructor]z": {
+          "name": "[constructor]z",
+          "kind": {
+            "constructor": 0
+          },
+          "params": [
+            {
+              "name": "a",
+              "type": "f64"
+            }
+          ],
+          "results": [
+            {
+              "type": 4
+            }
+          ]
+        }
+      },
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": "z",
+      "kind": "resource",
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": "z",
+      "kind": {
+        "type": 0
+      },
+      "owner": {
+        "world": 0
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "borrow": 1
+        }
+      },
+      "owner": null
+    },
+    {
+      "name": "big",
+      "kind": {
+        "record": {
+          "fields": [
+            {
+              "name": "x1",
+              "type": 2
+            }
+          ]
+        }
+      },
+      "owner": {
+        "world": 0
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "own": 0
+        }
+      },
+      "owner": null
+    }
+  ],
+  "packages": [
+    {
+      "name": "issues:issue165",
+      "docs": {
+        "contents": "https://github.com/bytecodealliance/wasm-tools-go/issues/165"
+      },
+      "interfaces": {
+        "types": 0
+      },
+      "worlds": {
+        "resources": 0
+      }
+    }
+  ]
+}

--- a/testdata/issues/issue165.wit.json.golden.wit
+++ b/testdata/issues/issue165.wit.json.golden.wit
@@ -1,0 +1,15 @@
+/// https://github.com/bytecodealliance/wasm-tools-go/issues/165
+package issues:issue165;
+
+interface types {
+	resource z {
+		constructor(a: f64);
+	}
+}
+
+world resources {
+	import types;
+	use types.{z};
+	record big { x1: borrow<z> }
+	export big-record: func(r: big);
+}

--- a/testdata/issues/issue165.wit.json.golden.wit
+++ b/testdata/issues/issue165.wit.json.golden.wit
@@ -12,4 +12,5 @@ world resources {
 	use types.{z};
 	record big { x1: borrow<z> }
 	export big-record: func(r: big);
+	export maybe-with-z: func(a: option<borrow<z>>);
 }

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -1373,7 +1373,7 @@ func (g *generator) liftOption(file *gen.File, dir wit.Direction, t *wit.TypeDef
 	b.WriteString("if f0 == 0 {\n")
 	b.WriteString("return")
 	b.WriteString("}\n")
-	stringio.Write(&b, "return ", g.cast(file, dir, t, t, g.cmCall(afile, "Some["+g.typeRep(afile, dir, o.Type)+"]", g.liftVariantCase(afile, dir, o.Type, flat[1:]))), "\n")
+	stringio.Write(&b, "return ", g.cast(afile, dir, t, t, g.cmCall(afile, "Some["+g.typeRep(afile, dir, o.Type)+"]", g.liftVariantCase(afile, dir, o.Type, flat[1:]))), "\n")
 	return g.typeDefLiftFunction(file, dir, t, input, b.String())
 }
 
@@ -1410,7 +1410,7 @@ func (g *generator) liftPrimitive(file *gen.File, dir wit.Direction, t wit.Type,
 
 func (g *generator) cast(file *gen.File, dir wit.Direction, from, to wit.Type, input string) string {
 	if castable(from, to) {
-		return "(" + g.typeRep(file, wit.Imported, to) + ")(" + input + ")"
+		return "(" + g.typeRep(file, dir, to) + ")(" + input + ")"
 	}
 	t := derefPointer(to)
 	if t != nil {

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -74,36 +74,6 @@ type param struct {
 	dir  wit.Direction
 }
 
-func (g *generator) goFunction(file *gen.File, tdir, dir wit.Direction, f *wit.Function, goName string) function {
-	scope := gen.NewScope(file)
-	out := function{
-		file:    file,
-		scope:   scope,
-		name:    goName,
-		params:  g.goParams(scope, tdir, f.Params),
-		results: g.goParams(scope, tdir, f.Results),
-	}
-	if len(out.results) == 1 && out.results[0].name == "" {
-		out.results[0].name = scope.DeclareName("result")
-	}
-	if dir == wit.Imported && f.IsMethod() {
-		out.receiver = out.params[0]
-		// out.params = out.params[1:]
-	}
-	return out
-}
-
-func (g *generator) goParams(scope gen.Scope, dir wit.Direction, params []wit.Param) []param {
-	out := make([]param, len(params))
-	for i, p := range params {
-		tdir, _ := g.typeDir(dir, p.Type)
-		out[i].name = scope.DeclareName(GoName(p.Name, false))
-		out[i].typ = p.Type
-		out[i].dir = tdir
-	}
-	return out
-}
-
 type typeUse struct {
 	pkg *gen.Package
 	dir wit.Direction
@@ -1528,6 +1498,36 @@ func (g *generator) ensureParamImports(file *gen.File, dir wit.Direction, params
 		// otherwise short package name may collide with param name.
 		_ = g.typeRep(file, dir, params[i].Type)
 	}
+}
+
+func (g *generator) goFunction(file *gen.File, tdir, dir wit.Direction, f *wit.Function, goName string) function {
+	scope := gen.NewScope(file)
+	out := function{
+		file:    file,
+		scope:   scope,
+		name:    goName,
+		params:  g.goParams(scope, tdir, f.Params),
+		results: g.goParams(scope, tdir, f.Results),
+	}
+	if len(out.results) == 1 && out.results[0].name == "" {
+		out.results[0].name = scope.DeclareName("result")
+	}
+	if dir == wit.Imported && f.IsMethod() {
+		out.receiver = out.params[0]
+		// out.params = out.params[1:]
+	}
+	return out
+}
+
+func (g *generator) goParams(scope gen.Scope, dir wit.Direction, params []wit.Param) []param {
+	out := make([]param, len(params))
+	for i, p := range params {
+		tdir, _ := g.typeDir(dir, p.Type)
+		out[i].name = scope.DeclareName(GoName(p.Name, false))
+		out[i].typ = p.Type
+		out[i].dir = tdir
+	}
+	return out
 }
 
 func (g *generator) declareFunction(owner wit.Ident, dir wit.Direction, f *wit.Function) (funcDecl, error) {

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -74,14 +74,14 @@ type param struct {
 	dir  wit.Direction
 }
 
-func goFunction(file *gen.File, tdir, dir wit.Direction, f *wit.Function, goName string) function {
+func (g *generator) goFunction(file *gen.File, tdir, dir wit.Direction, f *wit.Function, goName string) function {
 	scope := gen.NewScope(file)
 	out := function{
 		file:    file,
 		scope:   scope,
 		name:    goName,
-		params:  goParams(scope, tdir, f.Params),
-		results: goParams(scope, tdir, f.Results),
+		params:  g.goParams(scope, tdir, f.Params),
+		results: g.goParams(scope, tdir, f.Results),
 	}
 	if len(out.results) == 1 && out.results[0].name == "" {
 		out.results[0].name = scope.DeclareName("result")
@@ -93,12 +93,13 @@ func goFunction(file *gen.File, tdir, dir wit.Direction, f *wit.Function, goName
 	return out
 }
 
-func goParams(scope gen.Scope, dir wit.Direction, params []wit.Param) []param {
+func (g *generator) goParams(scope gen.Scope, dir wit.Direction, params []wit.Param) []param {
 	out := make([]param, len(params))
-	for i := range params {
-		out[i].name = scope.DeclareName(GoName(params[i].Name, false))
-		out[i].typ = params[i].Type
-		out[i].dir = dir
+	for i, p := range params {
+		tdir, _ := g.typeDir(dir, p.Type)
+		out[i].name = scope.DeclareName(GoName(p.Name, false))
+		out[i].typ = p.Type
+		out[i].dir = tdir
 	}
 	return out
 }
@@ -593,15 +594,38 @@ func declareDirectedName(scope gen.Scope, dir wit.Direction, name string) string
 	return scope.DeclareName(name)
 }
 
-func (g *generator) typeDecl(dir wit.Direction, t *wit.TypeDef) (typeDecl, bool) {
-	if decl, ok := g.types[dir][t]; ok {
+// typeDecl returns the typeDecl for [wit.Direction] dir and [wit.TypeDef] t, and whether it was declared.
+func (g *generator) typeDecl(dir wit.Direction, t *wit.TypeDef) (decl typeDecl, ok bool) {
+	if decl, ok = g.types[dir][t]; ok {
 		return decl, true
 	}
 	// This may return an exported type used by an imported function, which is disallowed,
 	// except for Component Model administrative functions like resource.drop.
 	// TODO: figure out a way to enforce that constraint here.
-	decl, ok := g.types[^dir&1][t]
+	decl, ok = g.types[^dir&1][t]
 	return decl, ok
+}
+
+// typeDir returns the declared type direction (imported or exported) for t.
+// If t is not a *[wit.TypeDef], then it returns dir, false.
+// If t is not declared, it returns dir, false.
+// If t is declared, but in the other direction, it returns the other direction, true.
+func (g *generator) typeDir(dir wit.Direction, t wit.Type) (tdir wit.Direction, ok bool) {
+	td, ok := t.(*wit.TypeDef)
+	if !ok {
+		return dir, false
+	}
+	if _, ok = g.types[dir][td]; ok {
+		return dir, true
+	}
+	// This may return an exported type used by an imported function, which is disallowed,
+	// except for Component Model administrative functions like resource.drop.
+	// TODO: figure out a way to enforce that constraint here.
+	dir2 := ^dir & 1
+	if _, ok = g.types[dir2][td]; ok {
+		return dir2, true
+	}
+	return dir, false
 }
 
 func (g *generator) typeDefRep(file *gen.File, dir wit.Direction, t *wit.TypeDef, goName string) string {
@@ -1057,7 +1081,7 @@ func (g *generator) typeDefLowerFunction(file *gen.File, dir wit.Direction, t *w
 	if !ok {
 		afile := g.abiFile(file.Package)
 		name := afile.DeclareName("lower_" + g.typeDefGoName(dir, t))
-		f = goFunction(afile, dir, wit.Imported, wit.LowerFunction(t), name)
+		f = g.goFunction(afile, dir, wit.Imported, wit.LowerFunction(t), name)
 		g.lowerFunctions[use] = f
 		stringio.Write(afile, "func ", name, g.functionSignature(afile, f), " {\n", body, "}\n\n")
 	}
@@ -1272,7 +1296,7 @@ func (g *generator) typeDefLiftFunction(file *gen.File, dir wit.Direction, t *wi
 	if !ok {
 		afile := g.abiFile(file.Package)
 		name := afile.DeclareName("lift_" + g.typeDefGoName(dir, t))
-		f = goFunction(afile, dir, wit.Imported, wit.LiftFunction(t), name)
+		f = g.goFunction(afile, dir, wit.Imported, wit.LiftFunction(t), name)
 		g.liftFunctions[use] = f
 		stringio.Write(afile, "func ", name, g.functionSignature(afile, f), " {\n", body, "}\n\n")
 	}
@@ -1594,8 +1618,8 @@ func (g *generator) declareFunction(owner wit.Ident, dir wit.Direction, f *wit.F
 	}
 
 	fdecl := funcDecl{
-		f:          goFunction(file, tdir, dir, f, funcName),
-		wasm:       goFunction(file, tdir, dir, wasm, wasmName),
+		f:          g.goFunction(file, tdir, dir, f, funcName),
+		wasm:       g.goFunction(file, tdir, dir, wasm, wasmName),
 		linkerName: linkerName,
 	}
 	g.functions[dir][f] = fdecl
@@ -1879,9 +1903,9 @@ func (g *generator) defineExportedFunction(owner wit.Ident, f *wit.Function, dec
 			flat := p.typ.Flat()
 			var input string
 			if len(flat) > 0 && len(decl.wasm.params) > 0 {
-				input = g.liftTypeInput(file, dir, p.typ, decl.wasm.params[i:i+len(flat)])
+				input = g.liftTypeInput(file, p.dir, p.typ, decl.wasm.params[i:i+len(flat)])
 			}
-			stringio.Write(&b, p.name, " := ", g.liftType(file, dir, p.typ, input), "\n")
+			stringio.Write(&b, p.name, " := ", g.liftType(file, p.dir, p.typ, input), "\n")
 			i += len(flat)
 		}
 	}


### PR DESCRIPTION
Fixes #165.

The real fix is probably to annotate type definitions in `wasm-tools` with direction (imported or exported).