### PR TITLE
wit, wit/bindgen: gracefully handle unnamed (yet named) interfaces in worlds. Fixes #170.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - [#161](https://github.com/bytecodealliance/wasm-tools-go/issues/161): correctly handle `constructor` as a WIT keyword in wit.
 - [#165](https://github.com/bytecodealliance/wasm-tools-go/issues/165): fixed use of imported types in exported functions.
 - [#167](https://github.com/bytecodealliance/wasm-tools-go/issues/167): fixed a logic flaw in `TestHasBorrow`.
+- [#170](https://github.com/bytecodealliance/wasm-tools-go/issues/170): resolve implied names for interface imports and exports in a world.
 
 ## [v0.2.0] — 2024-09-05
 

--- a/testdata/issues/issue170.wit
+++ b/testdata/issues/issue170.wit
@@ -1,0 +1,12 @@
+package issues:issue170;
+
+world w {
+	export example: interface {
+		resource r {
+			constructor(a: f64);
+			get-a: func() -> f64;
+			set-a: func(a: f64);
+			add: static func(r: r, a: f64) -> r;
+		}
+	}
+}

--- a/testdata/issues/issue170.wit.json
+++ b/testdata/issues/issue170.wit.json
@@ -1,0 +1,135 @@
+{
+  "worlds": [
+    {
+      "name": "w",
+      "imports": {},
+      "exports": {
+        "example": {
+          "interface": {
+            "id": 0
+          }
+        }
+      },
+      "package": 0
+    }
+  ],
+  "interfaces": [
+    {
+      "name": null,
+      "types": {
+        "r": 0
+      },
+      "functions": {
+        "[constructor]r": {
+          "name": "[constructor]r",
+          "kind": {
+            "constructor": 0
+          },
+          "params": [
+            {
+              "name": "a",
+              "type": "f64"
+            }
+          ],
+          "results": [
+            {
+              "type": 2
+            }
+          ]
+        },
+        "[method]r.get-a": {
+          "name": "[method]r.get-a",
+          "kind": {
+            "method": 0
+          },
+          "params": [
+            {
+              "name": "self",
+              "type": 1
+            }
+          ],
+          "results": [
+            {
+              "type": "f64"
+            }
+          ]
+        },
+        "[method]r.set-a": {
+          "name": "[method]r.set-a",
+          "kind": {
+            "method": 0
+          },
+          "params": [
+            {
+              "name": "self",
+              "type": 1
+            },
+            {
+              "name": "a",
+              "type": "f64"
+            }
+          ],
+          "results": []
+        },
+        "[static]r.add": {
+          "name": "[static]r.add",
+          "kind": {
+            "static": 0
+          },
+          "params": [
+            {
+              "name": "r",
+              "type": 2
+            },
+            {
+              "name": "a",
+              "type": "f64"
+            }
+          ],
+          "results": [
+            {
+              "type": 2
+            }
+          ]
+        }
+      },
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": "r",
+      "kind": "resource",
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "borrow": 0
+        }
+      },
+      "owner": null
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "own": 0
+        }
+      },
+      "owner": null
+    }
+  ],
+  "packages": [
+    {
+      "name": "issues:issue170",
+      "interfaces": {},
+      "worlds": {
+        "w": 0
+      }
+    }
+  ]
+}

--- a/testdata/issues/issue170.wit.json.golden.wit
+++ b/testdata/issues/issue170.wit.json.golden.wit
@@ -1,0 +1,12 @@
+package issues:issue170;
+
+world w {
+	export example: interface {
+		resource r {
+			constructor(a: f64);
+			get-a: func() -> f64;
+			set-a: func(a: f64);
+			add: static func(r: r, a: f64) -> r;
+		}
+	}
+}

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -544,10 +544,9 @@ func typeDefOwner(t *wit.TypeDef) wit.Ident {
 		id.Extension = owner.Name
 	case *wit.Interface:
 		id = owner.Package.Name
-		if owner.Name == nil {
-			id.Extension = "unknown"
-		} else {
-			id.Extension = *owner.Name
+		id.Extension = owner.InterfaceName()
+		if id.Extension == "" {
+			panic(fmt.Sprintf("BUG: unnamed interface owner of %#v", t))
 		}
 	}
 	return id

--- a/wit/testdata_test.go
+++ b/wit/testdata_test.go
@@ -361,10 +361,9 @@ func TestInterfaceNameIsNotNil(t *testing.T) {
 					name += "#" + *face.Name
 				}
 				t.Run(name, func(t *testing.T) {
-					// TODO: fix this, since anonymous imported interfaces have nil Name field
-					// if face.Name == nil {
-					// 	t.Error("Name is nil")
-					// }
+					if face.InterfaceName() == "" {
+						t.Error("empty or nil name")
+					}
 				})
 			}
 		})
@@ -421,8 +420,8 @@ func TestTypeDefRootOwnerNamesNotNil(t *testing.T) {
 							t.Error("Owner.Name is empty")
 						}
 					case *Interface:
-						if owner.Name == nil {
-							t.Error("Owner.Name is nil")
+						if owner.InterfaceName() == "" {
+							t.Error("Owner.Name is nil or Owner.InterfaceName() is empty")
 						}
 					}
 				})


### PR DESCRIPTION
- **testdata/issues: add test case for #170**
- **wit: add Interface.InterfaceName() method**
