### PR TITLE
wit, wit/bindgen: correctly generate linker names for world-level functions and interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - [#165](https://github.com/bytecodealliance/wasm-tools-go/issues/165): fixed use of imported types in exported functions.
 - [#167](https://github.com/bytecodealliance/wasm-tools-go/issues/167): fixed a logic flaw in `TestHasBorrow`.
 - [#170](https://github.com/bytecodealliance/wasm-tools-go/issues/170): resolve implied names for interface imports and exports in a world.
+- [#175](https://github.com/bytecodealliance/wasm-tools-go/issues/175): generated correct symbol names for imported and exported functions in worlds (`$root`) or interfaces declared inline in worlds.
 
 ## [v0.2.0] — 2024-09-05
 

--- a/testdata/issues/issue175.wit
+++ b/testdata/issues/issue175.wit
@@ -10,5 +10,6 @@ world w {
 			add: static func(r: r, a: f64) -> r;
 		}
 	}
-	export f2: func() -> s64;
+	import f2: func() -> f32;
+	export f3: func() -> s64;
 }

--- a/testdata/issues/issue175.wit
+++ b/testdata/issues/issue175.wit
@@ -1,0 +1,14 @@
+package issues:issue175;
+
+world w {
+	export example: interface {
+		f1: func() -> s32;
+		resource r {
+			constructor(a: f64);
+			get-a: func() -> f64;
+			set-a: func(a: f64);
+			add: static func(r: r, a: f64) -> r;
+		}
+	}
+	export f2: func() -> s64;
+}

--- a/testdata/issues/issue175.wit.json
+++ b/testdata/issues/issue175.wit.json
@@ -2,11 +2,24 @@
   "worlds": [
     {
       "name": "w",
-      "imports": {},
-      "exports": {
+      "imports": {
         "f2": {
           "function": {
             "name": "f2",
+            "kind": "freestanding",
+            "params": [],
+            "results": [
+              {
+                "type": "f32"
+              }
+            ]
+          }
+        }
+      },
+      "exports": {
+        "f3": {
+          "function": {
+            "name": "f3",
             "kind": "freestanding",
             "params": [],
             "results": [

--- a/testdata/issues/issue175.wit.json
+++ b/testdata/issues/issue175.wit.json
@@ -1,0 +1,157 @@
+{
+  "worlds": [
+    {
+      "name": "w",
+      "imports": {},
+      "exports": {
+        "f2": {
+          "function": {
+            "name": "f2",
+            "kind": "freestanding",
+            "params": [],
+            "results": [
+              {
+                "type": "s64"
+              }
+            ]
+          }
+        },
+        "example": {
+          "interface": {
+            "id": 0
+          }
+        }
+      },
+      "package": 0
+    }
+  ],
+  "interfaces": [
+    {
+      "name": null,
+      "types": {
+        "r": 0
+      },
+      "functions": {
+        "f1": {
+          "name": "f1",
+          "kind": "freestanding",
+          "params": [],
+          "results": [
+            {
+              "type": "s32"
+            }
+          ]
+        },
+        "[constructor]r": {
+          "name": "[constructor]r",
+          "kind": {
+            "constructor": 0
+          },
+          "params": [
+            {
+              "name": "a",
+              "type": "f64"
+            }
+          ],
+          "results": [
+            {
+              "type": 2
+            }
+          ]
+        },
+        "[method]r.get-a": {
+          "name": "[method]r.get-a",
+          "kind": {
+            "method": 0
+          },
+          "params": [
+            {
+              "name": "self",
+              "type": 1
+            }
+          ],
+          "results": [
+            {
+              "type": "f64"
+            }
+          ]
+        },
+        "[method]r.set-a": {
+          "name": "[method]r.set-a",
+          "kind": {
+            "method": 0
+          },
+          "params": [
+            {
+              "name": "self",
+              "type": 1
+            },
+            {
+              "name": "a",
+              "type": "f64"
+            }
+          ],
+          "results": []
+        },
+        "[static]r.add": {
+          "name": "[static]r.add",
+          "kind": {
+            "static": 0
+          },
+          "params": [
+            {
+              "name": "r",
+              "type": 2
+            },
+            {
+              "name": "a",
+              "type": "f64"
+            }
+          ],
+          "results": [
+            {
+              "type": 2
+            }
+          ]
+        }
+      },
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": "r",
+      "kind": "resource",
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "borrow": 0
+        }
+      },
+      "owner": null
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "own": 0
+        }
+      },
+      "owner": null
+    }
+  ],
+  "packages": [
+    {
+      "name": "issues:issue175",
+      "interfaces": {},
+      "worlds": {
+        "w": 0
+      }
+    }
+  ]
+}

--- a/testdata/issues/issue175.wit.json.golden.wit
+++ b/testdata/issues/issue175.wit.json.golden.wit
@@ -1,0 +1,14 @@
+package issues:issue175;
+
+world w {
+	export f2: func() -> s64;
+	export example: interface {
+		resource r {
+			constructor(a: f64);
+			get-a: func() -> f64;
+			set-a: func(a: f64);
+			add: static func(r: r, a: f64) -> r;
+		}
+		f1: func() -> s32;
+	}
+}

--- a/testdata/issues/issue175.wit.json.golden.wit
+++ b/testdata/issues/issue175.wit.json.golden.wit
@@ -1,7 +1,8 @@
 package issues:issue175;
 
 world w {
-	export f2: func() -> s64;
+	import f2: func() -> f32;
+	export f3: func() -> s64;
 	export example: interface {
 		resource r {
 			constructor(a: f64);

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -1601,8 +1601,8 @@ func (g *generator) declareFunction(owner wit.TypeOwner, dir wit.Direction, f *w
 
 	case *wit.Method:
 		t := f.Type().(*wit.TypeDef)
-		if t.Package().Name.Package != ownerID.Package {
-			return nil, fmt.Errorf("cannot emit functions in package %s to type %s", ownerID.Package, t.Package().Name.String())
+		if t.Owner != owner {
+			return nil, fmt.Errorf("cannot emit methods in package %s on type %s", ownerID.Package, t.TypeName())
 		}
 		td, _ := g.typeDecl(tdir, t)
 		switch dir {

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -2194,19 +2194,28 @@ func (g *generator) packageFor(owner wit.TypeOwner) *gen.Package {
 }
 
 func (g *generator) newPackage(w *wit.World, i *wit.Interface, name string) (*gen.Package, error) {
-	var owner wit.TypeOwner = w
-	id := w.Package.Name
-	id.Extension = w.Name
+	var owner wit.TypeOwner
+	var id wit.Ident
 
 	if i == nil {
+		// Derive Go package from the WIT world
+		owner = w
+		id = w.Package.Name
+		id.Extension = w.Name
 		name = id.Extension
 	} else {
-		if i.Package != w.Package {
-			return nil, fmt.Errorf("BUG: world package %q != interface package %q", w.Package.Name.String(), i.Package.Name.String())
-		}
 		owner = i
-		if i.Name != nil {
+		if i.Name == nil {
+			// Derive Go package from the interface declared in the WIT world
+			if i.Package != w.Package {
+				return nil, fmt.Errorf("BUG: nested interface package %q != world package %q", i.Package.Name.String(), w.Package.Name.String())
+			}
+			id = w.Package.Name
+			id.Extension = w.Name
+		} else {
+			// Derive Go package from package-scoped interface
 			name = *i.Name
+			id = i.Package.Name
 			id.Extension = name
 		}
 	}

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -47,6 +47,9 @@ type typeDecl struct {
 }
 
 type funcDecl struct {
+	owner      wit.TypeOwner
+	dir        wit.Direction
+	f          *wit.Function
 	goFunc     function // The Go function
 	wasmFunc   function // The wasmimport or wasmexport function
 	linkerName string   // The wasmimport or wasmexport mangled linker name
@@ -1620,6 +1623,9 @@ func (g *generator) declareFunction(owner wit.TypeOwner, dir wit.Direction, f *w
 	}
 
 	fdecl := funcDecl{
+		owner:      owner,
+		dir:        dir,
+		f:          f,
 		goFunc:     g.goFunction(file, tdir, dir, f, funcName),
 		wasmFunc:   g.goFunction(file, tdir, dir, wasm, wasmName),
 		linkerName: linkerName,

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -206,7 +206,10 @@ func (g *generator) defineWorlds() error {
 	// fmt.Fprintf(os.Stderr, "Generating Go for %d world(s)\n", len(g.res.Worlds))
 	for i, w := range g.res.Worlds {
 		if matchWorld(w, g.opts.world) || (g.opts.world == "" && i == len(g.res.Worlds)-1) {
-			g.defineWorld(w)
+			err := g.defineWorld(w)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -362,7 +362,6 @@ func (g *generator) defineTypeDef(dir wit.Direction, t *wit.TypeDef, name string
 
 	// If an alias, get root
 	root := t.Root()
-	rootOwnerID := g.ownerIdent(root.Owner)
 	rootName := name
 	if root.Name != nil {
 		rootName = *root.Name
@@ -374,7 +373,7 @@ func (g *generator) defineTypeDef(dir wit.Direction, t *wit.TypeDef, name string
 	if wit.HasResource(t) {
 		stringio.Write(&b, dir.String(), " ")
 	}
-	stringio.Write(&b, root.WITKind(), " \"", rootOwnerID.String(), "#", rootName, "\".\n")
+	stringio.Write(&b, root.WITKind(), " \"", moduleName(root.Owner), "#", rootName, "\".\n")
 	b.WriteString("//\n")
 	if root != t {
 		// Type alias
@@ -402,7 +401,7 @@ func (g *generator) defineTypeDef(dir wit.Direction, t *wit.TypeDef, name string
 		xfile := g.exportsFileFor(t.Owner)
 		scope := g.exportScopes[t.Owner]
 		goName := scope.GetName(GoName(*t.Name, true))
-		stringio.Write(xfile, "\n// ", goName, " represents the caller-defined exports for ", root.WITKind(), " \"", rootOwnerID.String(), "#", rootName, "\".\n")
+		stringio.Write(xfile, "\n// ", goName, " represents the caller-defined exports for ", root.WITKind(), " \"", moduleName(root.Owner), "#", rootName, "\".\n")
 		stringio.Write(xfile, goName, " struct {")
 	}
 
@@ -1630,7 +1629,7 @@ func (g *generator) declareFunction(owner wit.TypeOwner, dir wit.Direction, f *w
 	case *wit.Method:
 		t := f.Type().(*wit.TypeDef)
 		if t.Owner != owner {
-			return nil, fmt.Errorf("cannot emit methods in package %s on type %s", g.ownerIdent(owner), t.TypeName())
+			return nil, fmt.Errorf("cannot emit methods in package %s on type %s", moduleName(owner), t.TypeName())
 		}
 		td, _ := g.typeDecl(tdir, t)
 		switch dir {
@@ -2201,8 +2200,7 @@ func (g *generator) exportsFileFor(owner wit.TypeOwner) *gen.File {
 	if len(file.Header) == 0 {
 		exports := file.GetName("Exports")
 		var b strings.Builder
-		id := g.ownerIdent(owner)
-		stringio.Write(&b, "// ", exports, " represents the caller-defined exports from \"", id.String(), "\".\n")
+		stringio.Write(&b, "// ", exports, " represents the caller-defined exports from \"", moduleName(owner), "\".\n")
 		stringio.Write(&b, "var ", exports, " struct {")
 		file.Header = b.String()
 	}

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -110,7 +110,7 @@ type generator struct {
 
 	// defined represent whether a world, interface, type, or function has been defined.
 	// It is indexed on wit.Direction, either Imported or Exported.
-	defined [2]map[any]bool
+	defined [2]map[wit.Node]bool
 
 	// ABI shapes for any type, use for variant and result Shape type parameters.
 	shapes map[typeUse]string
@@ -132,7 +132,7 @@ func newGenerator(res *wit.Resolve, opts ...Option) (*generator, error) {
 	for i := 0; i < 2; i++ {
 		g.types[i] = make(map[*wit.TypeDef]typeDecl)
 		g.functions[i] = make(map[*wit.Function]*funcDecl)
-		g.defined[i] = make(map[any]bool)
+		g.defined[i] = make(map[wit.Node]bool)
 	}
 	err := g.opts.apply(opts...)
 	if err != nil {
@@ -186,7 +186,7 @@ func (g *generator) detectVersionedPackages() {
 
 // define marks a world, interface, type, or function as defined.
 // It returns true if was newly defined.
-func (g *generator) define(dir wit.Direction, v any) (defined bool) {
+func (g *generator) define(dir wit.Direction, v wit.Node) (defined bool) {
 	if g.defined[dir][v] {
 		return false
 	}

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -558,7 +558,7 @@ func (g *generator) ownerIdent(owner wit.TypeOwner) wit.Ident {
 func moduleName(owner wit.TypeOwner) string {
 	switch owner := owner.(type) {
 	case *wit.World:
-		return ""
+		return "$root"
 	case *wit.Interface:
 		if owner.Name == nil {
 			return owner.InterfaceName()
@@ -1562,16 +1562,12 @@ func (g *generator) declareFunction(owner wit.TypeOwner, dir wit.Direction, f *w
 	switch dir {
 	case wit.Imported:
 		goPrefix = "wasmimport_"
-		if module == "" {
-			linkerName = "$root" + " " + f.Name
-		} else {
-			linkerName = module + " " + f.Name
-		}
+		linkerName = module + " " + f.Name
 
 	case wit.Exported:
 		scope = g.exportScopes[owner]
 		goPrefix = "wasmexport_"
-		if module == "" {
+		if module == "$root" {
 			linkerName = f.Name
 		} else {
 			linkerName = module + "#" + f.Name
@@ -1581,11 +1577,7 @@ func (g *generator) declareFunction(owner wit.TypeOwner, dir wit.Direction, f *w
 		dir = wit.Imported  // Imported function...
 		tdir = wit.Exported // ...with exported types
 		goPrefix = "wasmimport_"
-		if module == "" {
-			linkerName = "[export]" + f.Name // this should never happen, as worlds cannot export types
-		} else {
-			linkerName = "[export]" + module + " " + f.Name
-		}
+		linkerName = "[export]" + module + " " + f.Name
 
 	default:
 		return nil, errors.New("BUG: unknown direction " + dir.String())

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -101,9 +101,6 @@ type generator struct {
 	// exportScopes map WIT identifier paths to export scopes.
 	exportScopes map[wit.TypeOwner]gen.Scope
 
-	// interfaceIDs map wit.Interface to a qualified identifier.
-	interfaceIDs map[*wit.Interface]wit.Ident
-
 	// types map wit.TypeDef to their Go equivalent.
 	// It is indexed on wit.Direction, either Imported or Exported.
 	types [2]map[*wit.TypeDef]*typeDecl
@@ -129,7 +126,6 @@ func newGenerator(res *wit.Resolve, opts ...Option) (*generator, error) {
 		packages:       make(map[string]*gen.Package),
 		witPackages:    make(map[wit.TypeOwner]*gen.Package),
 		exportScopes:   make(map[wit.TypeOwner]gen.Scope),
-		interfaceIDs:   make(map[*wit.Interface]wit.Ident),
 		shapes:         make(map[typeUse]string),
 		lowerFunctions: make(map[typeUse]function),
 		liftFunctions:  make(map[typeUse]function),
@@ -295,7 +291,6 @@ func (g *generator) defineInterface(w *wit.World, dir wit.Direction, i *wit.Inte
 		name = *i.Name
 	}
 	id.Extension = name
-	g.interfaceIDs[i] = id
 
 	pkg, err := g.newPackage(w, i, name)
 	if err != nil {
@@ -548,18 +543,6 @@ func (g *generator) declareTypeDef(file *gen.File, dir wit.Direction, t *wit.Typ
 	}
 
 	return decl, nil
-}
-
-func (g *generator) ownerIdent(owner wit.TypeOwner) wit.Ident {
-	var id wit.Ident
-	switch owner := owner.(type) {
-	case *wit.World:
-		id = owner.Package.Name
-		id.Extension = owner.Name
-	case *wit.Interface:
-		return g.interfaceIDs[owner]
-	}
-	return id
 }
 
 func moduleName(owner wit.TypeOwner) string {

--- a/wit/bindgen/testdata_test.go
+++ b/wit/bindgen/testdata_test.go
@@ -216,7 +216,7 @@ func TestGenerateTestdata(t *testing.T) {
 	}
 	err := loadTestdata(func(path string, res *wit.Resolve) error {
 		t.Run(path, func(t *testing.T) {
-			origin := "wit/bindgen/" + strings.TrimSuffix(strings.TrimPrefix(path, testdataPath), ".wit.json")
+			origin := strings.TrimSuffix(strings.TrimPrefix(path, testdataPath), ".wit.json")
 			validateGeneratedGo(t, res, origin)
 		})
 		return nil

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -62,6 +62,11 @@ type World struct {
 	Docs      Docs
 }
 
+// WITPackage returns the [Package] this [World] belongs to.
+func (w *World) WITPackage() *Package {
+	return w.Package
+}
+
 // AllFunctions returns a [sequence] that yields each [Function] in a [World].
 // The sequence stops if yield returns false.
 //
@@ -125,6 +130,11 @@ type Interface struct {
 	Package   *Package  // the Package this Interface belongs to
 	Stability Stability // WIT @since or @unstable (nil if unknown)
 	Docs      Docs
+}
+
+// WITPackage returns the [Package] this [Interface] belongs to.
+func (i *Interface) WITPackage() *Package {
+	return i.Package
 }
 
 // InterfaceName performs a best-effort guess at the [Interface] name,
@@ -214,17 +224,6 @@ func (t *TypeDef) Root() *TypeDef {
 			return t
 		}
 	}
-}
-
-// Package returns the [Package] that t is associated with, if any.
-func (t *TypeDef) Package() *Package {
-	switch owner := t.Owner.(type) {
-	case *Interface:
-		return owner.Package
-	case *World:
-		return owner.Package
-	}
-	return nil
 }
 
 // Constructor returns the constructor for [TypeDef] t, or nil if none.
@@ -1042,6 +1041,7 @@ func (s *Stream) hasResource() bool { return HasResource(s.Element) || HasResour
 type TypeOwner interface {
 	Node
 	AllFunctions() iterate.Seq[*Function]
+	WITPackage() *Package
 	isTypeOwner()
 }
 

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -137,44 +137,6 @@ func (i *Interface) WITPackage() *Package {
 	return i.Package
 }
 
-// InterfaceName performs a best-effort guess at the [Interface] name,
-// which may be found by scanning its parent package.
-func (i *Interface) InterfaceName() string {
-	if i.Name != nil {
-		return *i.Name
-	}
-	if i.Package == nil {
-		return ""
-	}
-	var done bool
-	var name string
-	scanWorldItem := func(key string, item WorldItem) bool {
-		if ref, ok := item.(*InterfaceRef); ok && ref.Interface == i && key != "" {
-			name = key
-			done = true
-		}
-		return !done
-	}
-	i.Package.Worlds.All()(func(_ string, w *World) bool {
-		w.Imports.All()(scanWorldItem)
-		if !done {
-			w.Exports.All()(scanWorldItem)
-		}
-		return !done
-	})
-	if done {
-		return name
-	}
-	i.Package.Interfaces.All()(func(key string, face *Interface) bool {
-		if face == i && key != "" {
-			name = key
-			done = true
-		}
-		return !done
-	})
-	return name
-}
-
 // AllFunctions returns a [sequence] that yields each [Function] in an [Interface].
 // The sequence stops if yield returns false.
 //

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -62,13 +62,6 @@ type World struct {
 	Docs      Docs
 }
 
-// Ident returns a fully-qualified [Ident] for this [World].
-func (w *World) Ident() Ident {
-	id := w.Package.Name
-	id.Extension = w.Name
-	return id
-}
-
 // WITPackage returns the [Package] this [World] belongs to.
 func (w *World) WITPackage() *Package {
 	return w.Package
@@ -137,13 +130,6 @@ type Interface struct {
 	Package   *Package  // the Package this Interface belongs to
 	Stability Stability // WIT @since or @unstable (nil if unknown)
 	Docs      Docs
-}
-
-// Ident returns a fully-qualified [Ident] for this [Interface].
-func (i *Interface) Ident() Ident {
-	id := i.Package.Name
-	id.Extension = i.InterfaceName()
-	return id
 }
 
 // WITPackage returns the [Package] this [Interface] belongs to.

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -62,6 +62,13 @@ type World struct {
 	Docs      Docs
 }
 
+// Ident returns a fully-qualified [Ident] for this [World].
+func (w *World) Ident() Ident {
+	id := w.Package.Name
+	id.Extension = w.Name
+	return id
+}
+
 // WITPackage returns the [Package] this [World] belongs to.
 func (w *World) WITPackage() *Package {
 	return w.Package
@@ -130,6 +137,13 @@ type Interface struct {
 	Package   *Package  // the Package this Interface belongs to
 	Stability Stability // WIT @since or @unstable (nil if unknown)
 	Docs      Docs
+}
+
+// Ident returns a fully-qualified [Ident] for this [Interface].
+func (i *Interface) Ident() Ident {
+	id := i.Package.Name
+	id.Extension = i.InterfaceName()
+	return id
 }
 
 // WITPackage returns the [Package] this [Interface] belongs to.

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -363,7 +363,7 @@ func (t *TypeDef) WIT(ctx Node, name string) string {
 		if t.Owner == ctx.Owner && t.Name != nil {
 			return "type " + escape(name) + " = " + escape(*t.Name)
 		}
-		ownerName := relativeName(t.Owner, ctx.Package())
+		ownerName := relativeName(t.Owner, ctx.Owner.WITPackage())
 		if t.Name != nil && *t.Name != name {
 			return fmt.Sprintf("use %s.{%s as %s};", ownerName, escape(*t.Name), escape(name))
 		}


### PR DESCRIPTION
Functions and interfaces imported into or exported directly from a world will now have the correct module name (`$root`).

For interfaces nested under a world, the generated Go package will be nested under the world’s package, e.g.:

```wit
package issues:issue175;

world w {
	export example: interface {
		f1: func() -> s32;
	}
	import f2: func() -> f32;
	export f3: func() -> s64;
}
```

Creates two Go packages:

1. `issues/issue175/w` exporting or importing functions with module `$root`
2. `issues/issue175/w/example` exporting or importing functions with module `example`

Fixes #175.

