### PR TITLE
generate: output WIT package to the generated code directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - `wit-bindgen-go generate` now accepts a remote registry reference to pull down a WIT package and generate the Go code. Example: `wit-bindgen-go generate ghcr.io/webassembly/wasi/http:0.2.0`.
+- `wit-bindgen-go generate` now writes the WIT next to the generated code.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - `wit-bindgen-go generate` now accepts a remote registry reference to pull down a WIT package and generate the Go code. Example: `wit-bindgen-go generate ghcr.io/webassembly/wasi/http:0.2.0`.
-- `wit-bindgen-go generate` now writes the WIT next to the generated code.
+- `wit-bindgen-go generate` now writes the WIT next to the generated code in directory `wit`
 
 ### Fixed
 

--- a/cmd/wit-bindgen-go/cmd/generate/generate.go
+++ b/cmd/wit-bindgen-go/cmd/generate/generate.go
@@ -202,7 +202,8 @@ func writeWITPackage(res *wit.Resolve, cfg *config) error {
 	if err := os.MkdirAll(witDir, cfg.outPerm); err != nil {
 		return err
 	}
-	fmt.Fprintf(os.Stderr, "Generated WIT files to: %s\n", witDir)
+	witFilePath := filepath.Join(witDir, "webassembly.wit")
+	fmt.Fprintf(os.Stderr, "Generated WIT files to: %s\n", witFilePath)
 
 	wasmTools, err := exec.LookPath("wasm-tools")
 	if err != nil {
@@ -210,7 +211,7 @@ func writeWITPackage(res *wit.Resolve, cfg *config) error {
 	}
 
 	var stderr bytes.Buffer
-	wasmCmd := exec.Command(wasmTools, "component", "wit", "--all-features", "--out-dir", witDir)
+	wasmCmd := exec.Command(wasmTools, "component", "wit", "--all-features", "--output", witFilePath)
 	wasmCmd.Stderr = &stderr
 	wasmCmd.Stdin = bytes.NewReader([]byte(res.WIT(nil, "")))
 

--- a/cmd/wit-bindgen-go/cmd/generate/generate.go
+++ b/cmd/wit-bindgen-go/cmd/generate/generate.go
@@ -202,8 +202,7 @@ func writeWITPackage(res *wit.Resolve, cfg *config) error {
 	if err := os.MkdirAll(witDir, cfg.outPerm); err != nil {
 		return err
 	}
-	witFilePath := filepath.Join(witDir, "webassembly.wit.wasm")
-	fmt.Fprintf(os.Stderr, "Generated WIT file: %s\n", witFilePath)
+	fmt.Fprintf(os.Stderr, "Generated WIT files to: %s\n", witDir)
 
 	wasmTools, err := exec.LookPath("wasm-tools")
 	if err != nil {
@@ -211,7 +210,7 @@ func writeWITPackage(res *wit.Resolve, cfg *config) error {
 	}
 
 	var stderr bytes.Buffer
-	wasmCmd := exec.Command(wasmTools, "component", "wit", "--wasm", "--all-features", "--output", witFilePath)
+	wasmCmd := exec.Command(wasmTools, "component", "wit", "--all-features", "--out-dir", witDir)
 	wasmCmd.Stderr = &stderr
 	wasmCmd.Stdin = bytes.NewReader([]byte(res.WIT(nil, "")))
 

--- a/cmd/wit-bindgen-go/cmd/generate/generate.go
+++ b/cmd/wit-bindgen-go/cmd/generate/generate.go
@@ -1,15 +1,18 @@
 package generate
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/bytecodealliance/wasm-tools-go/internal/codec"
 	"github.com/bytecodealliance/wasm-tools-go/internal/go/gen"
 	"github.com/bytecodealliance/wasm-tools-go/internal/witcli"
+	"github.com/bytecodealliance/wasm-tools-go/wit"
 	"github.com/bytecodealliance/wasm-tools-go/wit/bindgen"
 	"github.com/urfave/cli/v3"
 )
@@ -99,7 +102,11 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	return writeGoPackages(packages, cfg)
+	if err := writeGoPackages(packages, cfg); err != nil {
+		return err
+	}
+
+	return writeWITPackage(res, cfg)
 }
 
 func parseFlags(cmd *cli.Command) (*config, error) {
@@ -186,6 +193,31 @@ func writeGoPackages(packages []*gen.Package, cfg *config) error {
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+func writeWITPackage(res *wit.Resolve, cfg *config) error {
+	witDir := filepath.Join(cfg.out, "wit")
+	if err := os.MkdirAll(witDir, cfg.outPerm); err != nil {
+		return err
+	}
+	witFilePath := filepath.Join(witDir, "webassembly.wit.wasm")
+	fmt.Fprintf(os.Stderr, "Generated WIT file: %s\n", witFilePath)
+
+	wasmTools, err := exec.LookPath("wasm-tools")
+	if err != nil {
+		return err
+	}
+
+	var stderr bytes.Buffer
+	wasmCmd := exec.Command(wasmTools, "component", "wit", "--wasm", "--all-features", "--output", witFilePath)
+	wasmCmd.Stderr = &stderr
+	wasmCmd.Stdin = bytes.NewReader([]byte(res.WIT(nil, "")))
+
+	if err := wasmCmd.Run(); err != nil {
+		fmt.Fprint(os.Stderr, stderr.String())
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
This PR allows the generator to output WIT package to th generated Go directory. builds on top of #146 

TODO: 
- ~~needs a rebase once #146 merges to main.~~