### PR TITLE
cm: use HostLayout in all structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added type constraints `AnyList`, `AnyResult`, and `AnyVariant` in package `cm` to constrain generic functions accepting any of those types.
+- All `struct` types in package `cm` now include `structs.HostLayout` on Go 1.23 or later.
+
 ## [v0.2.1] — 2024-09-26
 
 ### Added

--- a/cm/abi.go
+++ b/cm/abi.go
@@ -24,13 +24,13 @@ func LiftString[T ~string, Data unsafe.Pointer | uintptr | *uint8, Len uint | ui
 }
 
 // LowerList lowers a [List] into a pair of Core WebAssembly types.
-func LowerList[L ~struct{ list[T] }, T any](list L) (*T, uint32) {
+func LowerList[L AnyList[T], T any](list L) (*T, uint32) {
 	l := (*List[T])(unsafe.Pointer(&list))
 	return l.data, uint32(l.len)
 }
 
 // LiftList lifts Core WebAssembly types into a [List].
-func LiftList[L ~struct{ list[T] }, T any, Data unsafe.Pointer | uintptr | *T, Len uint | uintptr | uint32 | uint64](data Data, len Len) L {
+func LiftList[L AnyList[T], T any, Data unsafe.Pointer | uintptr | *T, Len uint | uintptr | uint32 | uint64](data Data, len Len) L {
 	return L(NewList((*T)(unsafe.Pointer(data)), uint(len)))
 }
 

--- a/cm/list.go
+++ b/cm/list.go
@@ -4,12 +4,23 @@ import "unsafe"
 
 // List represents a Component Model list.
 // The binary representation of list<T> is similar to a Go slice minus the cap field.
-type List[T any] struct{ list[T] }
+type List[T any] struct {
+	_ HostLayout
+	list[T]
+}
+
+// AnyList is a type constraint for generic functions that accept any [List] type.
+type AnyList[T any] interface {
+	~struct {
+		_ HostLayout
+		list[T]
+	}
+}
 
 // NewList returns a List[T] from data and len.
 func NewList[T any](data *T, len uint) List[T] {
 	return List[T]{
-		list[T]{
+		list: list[T]{
 			data: data,
 			len:  len,
 		},

--- a/cm/option.go
+++ b/cm/option.go
@@ -3,7 +3,10 @@ package cm
 // Option represents a Component Model [option<T>] type.
 //
 // [option<T>]: https://component-model.bytecodealliance.org/design/wit.html#options
-type Option[T any] struct{ option[T] }
+type Option[T any] struct {
+	_ HostLayout
+	option[T]
+}
 
 // None returns an [Option] representing the none case,
 // equivalent to the zero value.
@@ -14,7 +17,7 @@ func None[T any]() Option[T] {
 // Some returns an [Option] representing the some case.
 func Some[T any](v T) Option[T] {
 	return Option[T]{
-		option[T]{
+		option: option[T]{
 			isSome: true,
 			some:   v,
 		},

--- a/cm/result.go
+++ b/cm/result.go
@@ -101,10 +101,7 @@ func (r *result[Shape, OK, Err]) validate() {
 // OK returns an OK result with shape Shape and type OK and Err.
 // Pass Result[OK, OK, Err] or Result[Err, OK, Err] as the first type argument.
 func OK[R AnyResult[Shape, OK, Err], Shape, OK, Err any](ok OK) R {
-	var r struct {
-		_ HostLayout
-		result[Shape, OK, Err]
-	}
+	var r Result[Shape, OK, Err]
 	r.validate()
 	r.isErr = ResultOK
 	*((*OK)(unsafe.Pointer(&r.data))) = ok
@@ -114,10 +111,7 @@ func OK[R AnyResult[Shape, OK, Err], Shape, OK, Err any](ok OK) R {
 // Err returns an error result with shape Shape and type OK and Err.
 // Pass Result[OK, OK, Err] or Result[Err, OK, Err] as the first type argument.
 func Err[R AnyResult[Shape, OK, Err], Shape, OK, Err any](err Err) R {
-	var r struct {
-		_ HostLayout
-		result[Shape, OK, Err]
-	}
+	var r Result[Shape, OK, Err]
 	r.validate()
 	r.isErr = ResultErr
 	*((*Err)(unsafe.Pointer(&r.data))) = err

--- a/cm/result.go
+++ b/cm/result.go
@@ -17,7 +17,18 @@ type BoolResult bool
 // Result represents a result sized to hold the Shape type.
 // The size of the Shape type must be greater than or equal to the size of OK and Err types.
 // For results with two zero-length types, use [BoolResult].
-type Result[Shape, OK, Err any] struct{ result[Shape, OK, Err] }
+type Result[Shape, OK, Err any] struct {
+	_ HostLayout
+	result[Shape, OK, Err]
+}
+
+// AnyResult is a type constraint for generic functions that accept any [Result] type.
+type AnyResult[Shape, OK, Err any] interface {
+	~struct {
+		_ HostLayout
+		result[Shape, OK, Err]
+	}
+}
 
 // result represents the internal representation of a Component Model result type.
 type result[Shape, OK, Err any] struct {
@@ -89,8 +100,11 @@ func (r *result[Shape, OK, Err]) validate() {
 
 // OK returns an OK result with shape Shape and type OK and Err.
 // Pass Result[OK, OK, Err] or Result[Err, OK, Err] as the first type argument.
-func OK[R ~struct{ result[Shape, OK, Err] }, Shape, OK, Err any](ok OK) R {
-	var r struct{ result[Shape, OK, Err] }
+func OK[R AnyResult[Shape, OK, Err], Shape, OK, Err any](ok OK) R {
+	var r struct {
+		_ HostLayout
+		result[Shape, OK, Err]
+	}
 	r.validate()
 	r.isErr = ResultOK
 	*((*OK)(unsafe.Pointer(&r.data))) = ok
@@ -99,8 +113,11 @@ func OK[R ~struct{ result[Shape, OK, Err] }, Shape, OK, Err any](ok OK) R {
 
 // Err returns an error result with shape Shape and type OK and Err.
 // Pass Result[OK, OK, Err] or Result[Err, OK, Err] as the first type argument.
-func Err[R ~struct{ result[Shape, OK, Err] }, Shape, OK, Err any](err Err) R {
-	var r struct{ result[Shape, OK, Err] }
+func Err[R AnyResult[Shape, OK, Err], Shape, OK, Err any](err Err) R {
+	var r struct {
+		_ HostLayout
+		result[Shape, OK, Err]
+	}
 	r.validate()
 	r.isErr = ResultErr
 	*((*Err)(unsafe.Pointer(&r.data))) = err

--- a/cm/variant.go
+++ b/cm/variant.go
@@ -12,7 +12,18 @@ type Discriminant interface {
 // Variant represents a loosely-typed Component Model variant.
 // Shape and Align must be non-zero sized types. To create a variant with no associated
 // types, use an enum.
-type Variant[Tag Discriminant, Shape, Align any] struct{ variant[Tag, Shape, Align] }
+type Variant[Tag Discriminant, Shape, Align any] struct {
+	_ HostLayout
+	variant[Tag, Shape, Align]
+}
+
+// AnyVariant is a type constraint for generic functions that accept any [Variant] type.
+type AnyVariant[Tag Discriminant, Shape, Align any] interface {
+	~struct {
+		_ HostLayout
+		variant[Tag, Shape, Align]
+	}
+}
 
 // NewVariant returns a [Variant] with tag of type Disc, storage and GC shape of type Shape,
 // aligned to type Align, with a value of type T.
@@ -26,7 +37,7 @@ func NewVariant[Tag Discriminant, Shape, Align any, T any](tag Tag, data T) Vari
 
 // New returns a [Variant] with tag of type Disc, storage and GC shape of type Shape,
 // aligned to type Align, with a value of type T.
-func New[V ~struct{ variant[Tag, Shape, Align] }, Tag Discriminant, Shape, Align any, T any](tag Tag, data T) V {
+func New[V AnyVariant[Tag, Shape, Align], Tag Discriminant, Shape, Align any, T any](tag Tag, data T) V {
 	validateVariant[Tag, Shape, Align, T]()
 	var v variant[Tag, Shape, Align]
 	v.tag = tag
@@ -35,7 +46,7 @@ func New[V ~struct{ variant[Tag, Shape, Align] }, Tag Discriminant, Shape, Align
 }
 
 // Case returns a non-nil *T if the [Variant] case is equal to tag, otherwise it returns nil.
-func Case[T any, V ~struct{ variant[Tag, Shape, Align] }, Tag Discriminant, Shape, Align any](v *V, tag Tag) *T {
+func Case[T any, V AnyVariant[Tag, Shape, Align], Tag Discriminant, Shape, Align any](v *V, tag Tag) *T {
 	validateVariant[Tag, Shape, Align, T]()
 	v2 := (*variant[Tag, Shape, Align])(unsafe.Pointer(v))
 	if v2.tag == tag {


### PR DESCRIPTION
- **cm: include HostLayout everywhere; add AnyList, AnyResult, and AnyVariant type constraints**
- **cm: use Result instead of equivalent struct**
