### PR TITLE
.github/workflows/release: add a release GitHub Action workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,8 +76,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ls build/
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          if [[ "$TAG_NAME" =~ .+-pre.* ]]; then
+            PRERELEASE_ARGS="--prerelease --latest=false"
+          else
+            PRERELEASE_ARGS=""
+          fi
           gh release create "${{ github.ref_name }}" \
             --notes-file RELEASE_NOTES.md \
             --title "${{ github.ref_name }}" \
-            --prerelease \
+            $PRERELEASE_ARGS \
             build/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         goos: [linux, windows, darwin]
         goarch: [amd64, arm64]
-        wasm-tools-version: ["1.216.0"]
         exclude:
           - goos: windows
             goarch: arm64
@@ -27,11 +26,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-
-      - name: Set up wasm-tools
-        uses: bytecodealliance/actions/wasm-tools/setup@v1
-        with:
-          version: ${{ matrix.wasm-tools-version }}
 
       - name: Run Go tests
         run: go test -v ./...

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,13 +39,15 @@ jobs:
       - name: Build Binary
         run: |
           mkdir -p build
-          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o build/wit-bindgen-go_${{ matrix.goos }}_${{ matrix.goarch }} ./cmd/wit-bindgen-go
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o wit-bindgen-go ./cmd/wit-bindgen-go
+          tar -czvf build/wit-bindgen-go-${{ matrix.goos }}-${{ matrix.goarch }}.tgz wit-bindgen-go
+          rm wit-bindgen-go
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: wit-bindgen-go_${{ matrix.goos }}_${{ matrix.goarch }}
-          path: build/wit-bindgen-go_${{ matrix.goos }}_${{ matrix.goarch }}
+          path: build/wit-bindgen-go-${{ matrix.goos }}-${{ matrix.goarch }}.tgz
           retention-days: 1
 
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,6 +68,7 @@ jobs:
         run: |
           ls build/
           gh release create "${{ github.ref_name }}" \
-            --notes-file changelog.md \
+            --notes-file CHANGELOG.md \
             --title "${{ github.ref_name }}" \
+            --prerelease \
             build/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,73 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.*'
+
+jobs:
+  build:
+    name: Build Binaries
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64, arm64]
+        wasm-tools-version: ["1.216.0"]
+        exclude:
+          - goos: windows
+            goarch: arm64
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set up wasm-tools
+        uses: bytecodealliance/actions/wasm-tools/setup@v1
+        with:
+          version: ${{ matrix.wasm-tools-version }}
+
+      - name: Run Go tests
+        run: go test -v ./...
+
+      - name: Build Binary
+        run: |
+          mkdir -p build
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o build/wit-bindgen-go_${{ matrix.goos }}_${{ matrix.goarch }} ./cmd/wit-bindgen-go
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wit-bindgen-go_${{ matrix.goos }}_${{ matrix.goarch }}
+          path: build/wit-bindgen-go_${{ matrix.goos }}_${{ matrix.goarch }}
+          retention-days: 1
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: '**'  # downloads all artifacts
+          path: build/
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ls build/
+          gh release create "${{ github.ref_name }}" \
+            --notes-file changelog.md \
+            --title "${{ github.ref_name }}" \
+            build/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,13 +62,20 @@ jobs:
           name: '**'  # downloads all artifacts
           path: build/
 
+      - name: Extract Release Notes
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          cd $GITHUB_WORKSPACE
+          ./scripts/extract-changelog.sh $TAG_NAME > RELEASE_NOTES.md
+          cat RELEASE_NOTES.md
+
       - name: Create Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ls build/
           gh release create "${{ github.ref_name }}" \
-            --notes-file CHANGELOG.md \
+            --notes-file RELEASE_NOTES.md \
             --title "${{ github.ref_name }}" \
             --prerelease \
             build/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Added type constraints `AnyList`, `AnyResult`, and `AnyVariant` in package `cm` to constrain generic functions accepting any of those types.
 - All `struct` types in package `cm` now include `structs.HostLayout` on Go 1.23 or later.
+- Added a release workflow to publish tagged releases to GitHub.
 
 ## [v0.2.1] — 2024-09-26
 

--- a/scripts/extract-changelog.sh
+++ b/scripts/extract-changelog.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Inspired by https://stackoverflow.com/questions/40450238/parse-a-changelog-and-extract-changes-for-a-version
+# This script will extract the changelog for a specific version from the CHANGELOG.md file
+# Usage: ./extract-changelog.sh <version>
+version=$1
+
+awk -v ver="$version" '
+/^## \[.*\]/ {
+  if (p) exit
+  if ($0 ~ "^## \\[" ver "\\]") { p=1 }
+}
+p' CHANGELOG.md


### PR DESCRIPTION
the release workflow will be triggered when a new tag is pushed to the remote, and will build, test and release the wit-bindgen-go binaries to the GitHub release page. It runs on linux, macos and windows and on amd64, arm64 architectures.

the built binary name is named as `wit-bindgen-go-<os>-<arch>`.