### PR TITLE
wit/bindgen, cm: add String() method to variant types; Value() method to option types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Added type constraints `AnyList`, `AnyResult`, and `AnyVariant` in package `cm` to constrain generic functions accepting any of those types.
 - All `struct` types in package `cm` now include `structs.HostLayout` on Go 1.23 or later.
 - Added a release workflow to publish tagged releases to GitHub.
+- Variant types now implement `fmt.Stringer`, with a `String` method. Breaking: variant cases named `string` map to `String_` in Go.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - All `struct` types in package `cm` now include `structs.HostLayout` on Go 1.23 or later.
 - Added a release workflow to publish tagged releases to GitHub.
 - Variant types now implement `fmt.Stringer`, with a `String` method. Breaking: variant cases named `string` map to `String_` in Go.
+- `cm.Option[T]` types now have a `Value()` convenience method that returns the zero value for `T` if the option represents the none case. For example, this simplifies getting an empty string or slice from `option<string>` or `option<list<T>>`, respectively.
 
 ### Fixed
 

--- a/cm/option.go
+++ b/cm/option.go
@@ -46,3 +46,13 @@ func (o *option[T]) Some() *T {
 	}
 	return nil
 }
+
+// Value returns T if o represents the some case,
+// or the zero value of T if o represents the none case.
+func (o *option[T]) Value() T {
+	if !o.isSome {
+		var zero T
+		return zero
+	}
+	return o.some
+}

--- a/cm/option_test.go
+++ b/cm/option_test.go
@@ -10,6 +10,9 @@ func TestOption(t *testing.T) {
 	if got, want := o1.Some(), (*string)(nil); got != want {
 		t.Errorf("o1.Some: %v, expected %v", got, want)
 	}
+	if got, want := o1.Value(), (string)(""); got != want {
+		t.Errorf("o1.Value: %v, expected %v", got, want)
+	}
 
 	var o2 Option[uint32]
 	if got, want := o2.None(), true; got != want {
@@ -18,6 +21,9 @@ func TestOption(t *testing.T) {
 	if got, want := o2.Some(), (*uint32)(nil); got != want {
 		t.Errorf("o2.Some: %v, expected %v", got, want)
 	}
+	if got, want := o2.Value(), (uint32)(0); got != want {
+		t.Errorf("o2.Value: %v, expected %v", got, want)
+	}
 
 	o3 := Some(true)
 	if got, want := o3.None(), false; got != want {
@@ -25,5 +31,30 @@ func TestOption(t *testing.T) {
 	}
 	if got, want := o3.Some(), &o3.some; got != want {
 		t.Errorf("o3.Some: %v, expected %v", got, want)
+	}
+	if got, want := o3.Value(), true; got != want {
+		t.Errorf("o3.Value: %v, expected %v", got, want)
+	}
+
+	o4 := Some("hello")
+	if got, want := o4.None(), false; got != want {
+		t.Errorf("o4.None: %t, expected %t", got, want)
+	}
+	if got, want := o4.Some(), &o4.some; got != want {
+		t.Errorf("o4.Some: %v, expected %v", got, want)
+	}
+	if got, want := o4.Value(), "hello"; got != want {
+		t.Errorf("o4.Value: %v, expected %v", got, want)
+	}
+
+	o5 := Some(List[string]{})
+	if got, want := o5.None(), false; got != want {
+		t.Errorf("o5.None: %t, expected %t", got, want)
+	}
+	if got, want := o5.Some(), &o5.some; got != want {
+		t.Errorf("o5.Some: %v, expected %v", got, want)
+	}
+	if got, want := o5.Value(), (List[string]{}); got != want {
+		t.Errorf("o4.Value: %v, expected %v", got, want)
 	}
 }

--- a/testdata/codegen/allow-unused.wit
+++ b/testdata/codegen/allow-unused.wit
@@ -6,7 +6,7 @@ world bindings {
 
 interface component {
     variant unused-variant {
-		%string,
+        %string,
         %enum(unused-enum),
         %record(unused-record)
     }

--- a/testdata/codegen/allow-unused.wit
+++ b/testdata/codegen/allow-unused.wit
@@ -6,6 +6,7 @@ world bindings {
 
 interface component {
     variant unused-variant {
+		%string,
         %enum(unused-enum),
         %record(unused-record)
     }

--- a/testdata/codegen/allow-unused.wit.json
+++ b/testdata/codegen/allow-unused.wit.json
@@ -63,6 +63,10 @@
         "variant": {
           "cases": [
             {
+              "name": "string",
+              "type": null
+            },
+            {
               "name": "enum",
               "type": 0
             },

--- a/testdata/codegen/allow-unused.wit.json.golden.wit
+++ b/testdata/codegen/allow-unused.wit.json.golden.wit
@@ -4,6 +4,7 @@ interface component {
 	enum unused-enum { unused }
 	record unused-record { x: u32 }
 	variant unused-variant {
+		%string,
 		%enum(unused-enum),
 		%record(unused-record),
 	}


### PR DESCRIPTION
- **wit/bindgen: generate String() method for variant types**
- **cm: add Option.Value() method**
