### PR TITLE
cm: change list<T> len field to uintptr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - `wit-bindgen-go generate` now accepts a remote registry reference to pull down a WIT package and generate the Go code. Example: `wit-bindgen-go generate ghcr.io/webassembly/wasi/http:0.2.0`.
 
-### Fixed
+### Changed
 
+- `cm.List` now stores list length as a `uintptr`, permitted by the [Go wasm types proposal](https://github.com/golang/go/issues/66984). It was previously a `uint`, which was removed from the list of permitted types. There should be no change in the memory layout in TinyGo `GOARCH=wasm` or Go `GOARCH=wasm32` using 32-bit pointers.
 - `cm.Option[T].Value()` method now value receiver (not pointer receiver), so it can be chained.
 
 ## [v0.2.2] — 2024-10-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - `cm.List` now stores list length as a `uintptr`, permitted by the [Go wasm types proposal](https://github.com/golang/go/issues/66984). It was previously a `uint`, which was removed from the list of permitted types. There should be no change in the memory layout in TinyGo `GOARCH=wasm` or Go `GOARCH=wasm32` using 32-bit pointers.
+- The helper functions `cm.NewList`, `cm.LiftList`, and `cm.LiftString` now accept any integer type for `len`, defined as `cm.AnyInteger`.
 - `cm.Option[T].Value()` method now value receiver (not pointer receiver), so it can be chained.
 
 ## [v0.2.2] — 2024-10-03

--- a/cm/abi.go
+++ b/cm/abi.go
@@ -19,7 +19,7 @@ func LowerString[S ~string](s S) (*byte, uint32) {
 }
 
 // LiftString lifts Core WebAssembly types into a [string].
-func LiftString[T ~string, Data unsafe.Pointer | uintptr | *uint8, Len uint | uintptr | uint32 | uint64](data Data, len Len) T {
+func LiftString[T ~string, Data unsafe.Pointer | uintptr | *uint8, Len int | uint | uintptr | uint32 | uint64](data Data, len Len) T {
 	return T(unsafe.String((*uint8)(unsafe.Pointer(data)), int(len)))
 }
 
@@ -30,8 +30,8 @@ func LowerList[L AnyList[T], T any](list L) (*T, uint32) {
 }
 
 // LiftList lifts Core WebAssembly types into a [List].
-func LiftList[L AnyList[T], T any, Data unsafe.Pointer | uintptr | *T, Len uint | uintptr | uint32 | uint64](data Data, len Len) L {
-	return L(NewList((*T)(unsafe.Pointer(data)), uint(len)))
+func LiftList[L AnyList[T], T any, Data unsafe.Pointer | uintptr | *T, Len int | uint | uintptr | uint32 | uint64](data Data, len Len) L {
+	return L(NewList((*T)(unsafe.Pointer(data)), uintptr(len)))
 }
 
 // BoolToU32 converts a value whose underlying type is [bool] into a [uint32].

--- a/cm/abi.go
+++ b/cm/abi.go
@@ -2,6 +2,11 @@ package cm
 
 import "unsafe"
 
+// AnyInteger is a type constraint for any integer type.
+type AnyInteger interface {
+	~int | ~uint | ~uintptr | ~int8 | ~uint8 | ~int16 | ~uint16 | ~int32 | ~uint32 | ~int64 | ~uint64
+}
+
 // Reinterpret reinterprets the bits of type From into type T.
 // Will panic if the size of From is smaller than the size of To.
 func Reinterpret[T, From any](from From) (to T) {
@@ -19,7 +24,7 @@ func LowerString[S ~string](s S) (*byte, uint32) {
 }
 
 // LiftString lifts Core WebAssembly types into a [string].
-func LiftString[T ~string, Data unsafe.Pointer | uintptr | *uint8, Len int | uint | uintptr | uint32 | uint64](data Data, len Len) T {
+func LiftString[T ~string, Data unsafe.Pointer | uintptr | *uint8, Len AnyInteger](data Data, len Len) T {
 	return T(unsafe.String((*uint8)(unsafe.Pointer(data)), int(len)))
 }
 
@@ -30,8 +35,8 @@ func LowerList[L AnyList[T], T any](list L) (*T, uint32) {
 }
 
 // LiftList lifts Core WebAssembly types into a [List].
-func LiftList[L AnyList[T], T any, Data unsafe.Pointer | uintptr | *T, Len int | uint | uintptr | uint32 | uint64](data Data, len Len) L {
-	return L(NewList((*T)(unsafe.Pointer(data)), uintptr(len)))
+func LiftList[L AnyList[T], T any, Data unsafe.Pointer | uintptr | *T, Len AnyInteger](data Data, len Len) L {
+	return L(NewList((*T)(unsafe.Pointer(data)), len))
 }
 
 // BoolToU32 converts a value whose underlying type is [bool] into a [uint32].

--- a/cm/list.go
+++ b/cm/list.go
@@ -18,7 +18,7 @@ type AnyList[T any] interface {
 }
 
 // NewList returns a List[T] from data and len.
-func NewList[T any](data *T, len uint) List[T] {
+func NewList[T any](data *T, len uintptr) List[T] {
 	return List[T]{
 		list: list[T]{
 			data: data,
@@ -31,7 +31,7 @@ func NewList[T any](data *T, len uint) List[T] {
 // The underlying slice data is not copied, and the resulting List points at the
 // same array storage as the slice.
 func ToList[S ~[]T, T any](s S) List[T] {
-	return NewList[T](unsafe.SliceData([]T(s)), uint(len(s)))
+	return NewList[T](unsafe.SliceData([]T(s)), uintptr(len(s)))
 }
 
 // list represents the internal representation of a Component Model list.
@@ -40,7 +40,7 @@ func ToList[S ~[]T, T any](s S) List[T] {
 type list[T any] struct {
 	_    HostLayout
 	data *T
-	len  uint
+	len  uintptr
 }
 
 // Slice returns a Go slice representing the List.
@@ -54,7 +54,7 @@ func (l list[T]) Data() *T {
 }
 
 // Len returns the length of the list.
-// TODO: should this return an int instead of a uint?
-func (l list[T]) Len() uint {
+// TODO: should this return an int instead of a uintptr?
+func (l list[T]) Len() uintptr {
 	return l.len
 }

--- a/cm/list.go
+++ b/cm/list.go
@@ -18,11 +18,11 @@ type AnyList[T any] interface {
 }
 
 // NewList returns a List[T] from data and len.
-func NewList[T any](data *T, len uintptr) List[T] {
+func NewList[T any, Len int | uint | uintptr | int32 | uint32 | int64 | uint64](data *T, len Len) List[T] {
 	return List[T]{
 		list: list[T]{
 			data: data,
-			len:  len,
+			len:  uintptr(len),
 		},
 	}
 }

--- a/cm/list.go
+++ b/cm/list.go
@@ -18,7 +18,7 @@ type AnyList[T any] interface {
 }
 
 // NewList returns a List[T] from data and len.
-func NewList[T any, Len int | uint | uintptr | int32 | uint32 | int64 | uint64](data *T, len Len) List[T] {
+func NewList[T any, Len AnyInteger](data *T, len Len) List[T] {
 	return List[T]{
 		list: list[T]{
 			data: data,


### PR DESCRIPTION
`uint` was removed from the list of permitted types in https://github.com/golang/go/issues/66984.

- `cm.List` now stores list length as a `uintptr`, permitted by the [Go wasm types proposal](https://github.com/golang/go/issues/66984). It was previously a `uint`, which was removed from the list of permitted types. There should be no change in the memory layout in TinyGo `GOARCH=wasm` or Go `GOARCH=wasm32` using 32-bit pointers.
- The helper functions `cm.NewList`, `cm.LiftList`, and `cm.LiftString` now accept any integer type for `len`, defined as `cm.AnyInteger`.