### PR TITLE
wit, wit/bindgen: generate Go type aliases for WIT type aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- CLI: `wit-bindgen-go wit` now accepts a `--world` argument in the form of `imports`, `wasi:clocks/imports`, or `wasi:clocks/imports@0.2.0`. This filters the serialized WIT to a specific world and interfaces it references. This can be used to generate focused WIT for a specific world with a minimal set of dependencies.
-- `wit.(*Resolve).WIT()` and `wit.(*Package).WIT()` now accept a `*wit.World` as context to filter serialized WIT to a specific world.
+- Go [type aliases](https://go.dev/ref/spec#Alias_declarations) are now generated for each WIT type alias (`type foo = bar`). Deep chains of type aliases (`type b = a; type c = b;`) are fully supported. Generated documentation now reflects whether a type is an alias. Fixes [#204](https://github.com/bytecodealliance/wasm-tools-go/issues/204).
+- `wit-bindgen-go wit` now accepts a `--world` argument in the form of `imports`, `wasi:clocks/imports`, or `wasi:clocks/imports@0.2.0`. This filters the serialized WIT to a specific world and interfaces it references. This can be used to generate focused WIT for a specific world with a minimal set of dependencies.
 
 ### Changed
 
 - Method `wit.(*Package).WIT()` now interprets the non-empty string `name` argument as signal to render in single-file, multi-package braced form.
+- `wit.(*Resolve).WIT()` and `wit.(*Package).WIT()` now accept a `*wit.World` as context to filter serialized WIT to a specific world.
 
 ## [v0.2.4] — 2024-10-06
 

--- a/testdata/example/aliases.wit
+++ b/testdata/example/aliases.wit
@@ -1,0 +1,20 @@
+package example:aliases;
+
+interface i {
+	resource r {
+		m: func() -> u32;
+	}
+
+	type a = r;
+	type b = a;
+	type c = b;
+
+	fa: func(v: a);
+	fb: func(v: b);
+	fc: func(v: c);
+}
+
+world w {
+	import i;
+	export i;
+}

--- a/testdata/example/aliases.wit.json
+++ b/testdata/example/aliases.wit.json
@@ -1,0 +1,169 @@
+{
+  "worlds": [
+    {
+      "name": "w",
+      "imports": {
+        "interface-0": {
+          "interface": {
+            "id": 0
+          }
+        }
+      },
+      "exports": {
+        "interface-0": {
+          "interface": {
+            "id": 0
+          }
+        }
+      },
+      "package": 0
+    }
+  ],
+  "interfaces": [
+    {
+      "name": "i",
+      "types": {
+        "r": 0,
+        "a": 1,
+        "b": 2,
+        "c": 3
+      },
+      "functions": {
+        "[method]r.m": {
+          "name": "[method]r.m",
+          "kind": {
+            "method": 0
+          },
+          "params": [
+            {
+              "name": "self",
+              "type": 4
+            }
+          ],
+          "results": [
+            {
+              "type": "u32"
+            }
+          ]
+        },
+        "fa": {
+          "name": "fa",
+          "kind": "freestanding",
+          "params": [
+            {
+              "name": "v",
+              "type": 5
+            }
+          ],
+          "results": []
+        },
+        "fb": {
+          "name": "fb",
+          "kind": "freestanding",
+          "params": [
+            {
+              "name": "v",
+              "type": 6
+            }
+          ],
+          "results": []
+        },
+        "fc": {
+          "name": "fc",
+          "kind": "freestanding",
+          "params": [
+            {
+              "name": "v",
+              "type": 7
+            }
+          ],
+          "results": []
+        }
+      },
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": "r",
+      "kind": "resource",
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": "a",
+      "kind": {
+        "type": 0
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": "b",
+      "kind": {
+        "type": 1
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": "c",
+      "kind": {
+        "type": 2
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "borrow": 0
+        }
+      },
+      "owner": null
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "own": 1
+        }
+      },
+      "owner": null
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "own": 2
+        }
+      },
+      "owner": null
+    },
+    {
+      "name": null,
+      "kind": {
+        "handle": {
+          "own": 3
+        }
+      },
+      "owner": null
+    }
+  ],
+  "packages": [
+    {
+      "name": "example:aliases",
+      "interfaces": {
+        "i": 0
+      },
+      "worlds": {
+        "w": 0
+      }
+    }
+  ]
+}

--- a/testdata/example/aliases.wit.json.golden.wit
+++ b/testdata/example/aliases.wit.json.golden.wit
@@ -1,0 +1,18 @@
+package example:aliases;
+
+interface i {
+	resource r {
+		m: func() -> u32;
+	}
+	type a = r;
+	type b = a;
+	type c = b;
+	fa: func(v: a);
+	fb: func(v: b);
+	fc: func(v: c);
+}
+
+world w {
+	import i;
+	export i;
+}

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -31,7 +31,7 @@ const (
 
 	// Create Go type aliases for WIT type aliases.
 	// This has issues with types that are simultaenously imported and exported in WIT.
-	experimentCreateTypeAliases = false
+	experimentCreateTypeAliases = true
 
 	// Predeclare Go types for own<T> and borrow<T>.
 	// Currently broken.

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -354,25 +354,19 @@ func (g *generator) defineTypeDef(dir wit.Direction, t *wit.TypeDef, name string
 		return err
 	}
 
-	// If an alias, get root
-	root := t.Root()
-	rootName := name
-	if root.Name != nil {
-		rootName = *root.Name
-	}
-
 	// Define the type
 	var b bytes.Buffer
 	stringio.Write(&b, "// ", decl.name, " represents the ")
 	if wit.HasResource(t) {
 		stringio.Write(&b, dir.String(), " ")
 	}
-	stringio.Write(&b, root.WITKind(), " \"", g.moduleNames[root.Owner], "#", rootName, "\".\n")
+	stringio.Write(&b, t.WITKind(), " \"", g.moduleNames[t.Owner], "#", name, "\".\n")
 	b.WriteString("//\n")
-	if root != t {
+	parent := t.TypeDef()
+	if parent != t {
 		// Type alias
-		stringio.Write(&b, "// See [", g.typeRep(decl.file, dir, root), "] for more information.\n")
-		stringio.Write(&b, "type ", decl.name, " = ", g.typeRep(decl.file, dir, root), "\n\n")
+		stringio.Write(&b, "// See [", g.typeRep(decl.file, dir, parent), "] for more information.\n")
+		stringio.Write(&b, "type ", decl.name, " = ", g.typeRep(decl.file, dir, parent), "\n\n")
 	} else {
 		b.WriteString(formatDocComments(t.Docs.Contents, false))
 		b.WriteString("//\n")
@@ -395,7 +389,7 @@ func (g *generator) defineTypeDef(dir wit.Direction, t *wit.TypeDef, name string
 		xfile := g.exportsFileFor(t.Owner)
 		scope := g.exportScopes[t.Owner]
 		goName := scope.GetName(GoName(*t.Name, true))
-		stringio.Write(xfile, "\n// ", goName, " represents the caller-defined exports for ", root.WITKind(), " \"", g.moduleNames[root.Owner], "#", rootName, "\".\n")
+		stringio.Write(xfile, "\n// ", goName, " represents the caller-defined exports for ", t.WITKind(), " \"", g.moduleNames[t.Owner], "#", name, "\".\n")
 		stringio.Write(xfile, goName, " struct {")
 	}
 

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -29,10 +29,6 @@ const (
 // See https://pkg.go.dev/cmd/compile for more information.
 `
 
-	// Create Go type aliases for WIT type aliases.
-	// This has issues with types that are simultaenously imported and exported in WIT.
-	experimentCreateTypeAliases = true
-
 	// Predeclare Go types for own<T> and borrow<T>.
 	// Currently broken.
 	experimentPredeclareHandles = false
@@ -338,10 +334,6 @@ func (g *generator) defineInterface(w *wit.World, dir wit.Direction, i *wit.Inte
 }
 
 func (g *generator) defineTypeDef(dir wit.Direction, t *wit.TypeDef, name string) error {
-	if !experimentCreateTypeAliases && t.Root() != t {
-		return nil
-	}
-
 	if !g.define(dir, t) {
 		return nil
 	}
@@ -635,9 +627,6 @@ func (g *generator) typeRep(file *gen.File, dir wit.Direction, t wit.Type) strin
 		return "struct{}"
 
 	case *wit.TypeDef:
-		if !experimentCreateTypeAliases {
-			t = t.Root()
-		}
 		if decl, ok := g.typeDecl(dir, t); ok {
 			return file.RelativeName(decl.file.Package, decl.name)
 		}

--- a/wit/resolve.go
+++ b/wit/resolve.go
@@ -221,8 +221,19 @@ func (t *TypeDef) TypeName() string {
 	return ""
 }
 
-// Root returns the root [TypeDef] of [type alias] t.
-// If t is not a type alias, Root returns t.
+// TypeDef returns the parent [TypeDef] of [TypeDef] t.
+// If t is not a [type alias], TypeDef returns t.
+//
+// [type alias]: https://component-model.bytecodealliance.org/design/wit.html#type-aliases
+func (t *TypeDef) TypeDef() *TypeDef {
+	if t, ok := t.Kind.(*TypeDef); ok {
+		return t
+	}
+	return t
+}
+
+// Root returns the root [TypeDef] of [TypeDef] t.
+// If t is not a [type alias], Root returns t.
 //
 // [type alias]: https://component-model.bytecodealliance.org/design/wit.html#type-aliases
 func (t *TypeDef) Root() *TypeDef {

--- a/wit/wit.go
+++ b/wit/wit.go
@@ -347,8 +347,10 @@ func (i *Interface) WIT(ctx Node, name string) string {
 
 // WITKind returns the [WIT] kind.
 func (t *TypeDef) WITKind() string {
-	// TODO: should this be prefixed with "alias" if t.Root() != t?
-	return t.Root().Kind.WITKind()
+	if alias := t.TypeDef(); alias != t {
+		return "type alias"
+	}
+	return t.Kind.WITKind()
 }
 
 // WIT returns the [WIT] text format for [TypeDef] t.


### PR DESCRIPTION
Go [type aliases](https://go.dev/ref/spec#Alias_declarations) are now generated for each WIT type alias (`type foo = bar`). Deep chains of type aliases (`type b = a; type c = b;`) are fully supported. Generated documentation now reflects whether a type is an alias.

For example, given the following WIT:

```wit
package example:aliases;

interface i {
	resource r {
		m: func() -> u32;
	}

	type a = r;
	type b = a;
	type c = b;

	fa: func(v: a);
	fb: func(v: b);
	fc: func(v: c);
}

world w {
	import i;
	export i;
}
```

Generates the following Go:

```go
// R represents the imported resource "example:aliases/i#r".
//
//	resource r
type R cm.Resource

// A represents the imported type alias "example:aliases/i#a".
//
// See [R] for more information.
type A = R

// B represents the imported type alias "example:aliases/i#b".
//
// See [A] for more information.
type B = A

// C represents the imported type alias "example:aliases/i#c".
//
// See [B] for more information.
type C = B
```

Fixes #204.