### PR TITLE
wit/bindgen: generate pruned WIT file for each WIT world in the relevant Go package directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Go [type aliases](https://go.dev/ref/spec#Alias_declarations) are now generated for each WIT type alias (`type foo = bar`). Deep chains of type aliases (`type b = a; type c = b;`) are fully supported. Generated documentation now reflects whether a type is an alias. Fixes [#204](https://github.com/bytecodealliance/wasm-tools-go/issues/204).
 - `go:wasmimport` and `go:wasmexport` functions are now generated in a separate `.wasm.go` file. This helps enable testing or use of generated packages outside of WebAssembly.
+- `wit-bindgen-go generate` now generates a WIT file for each WIT world in its corresponding Go package directory. For example the `wasi:http/proxy` world would generate `wasi/http/proxy/proxy.wit`.
 - `wit-bindgen-go wit` now accepts a `--world` argument in the form of `imports`, `wasi:clocks/imports`, or `wasi:clocks/imports@0.2.0`. This filters the serialized WIT to a specific world and interfaces it references. This can be used to generate focused WIT for a specific world with a minimal set of dependencies.
 
 ### Changed

--- a/internal/go/gen/package.go
+++ b/internal/go/gen/package.go
@@ -9,7 +9,7 @@ type Package struct {
 	// Name is the short Go package name, e.g. "json"
 	Name string
 
-	// Files is the list of Go source files in this package.
+	// Files is the list of Go and non-Go files in this package.
 	Files map[string]*File
 
 	// Declared tracks declared package-scoped identifiers,

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -224,17 +224,20 @@ func (g *generator) defineWorld(w *wit.World) error {
 	if err != nil {
 		return err
 	}
-	file := g.fileFor(w)
 
-	{
-		var b strings.Builder
-		stringio.Write(&b, "Package ", pkg.Name, " represents the ", w.WITKind(), " \"", g.moduleNames[w], "\".\n")
-		if w.Docs.Contents != "" {
-			b.WriteString("\n")
-			b.WriteString(w.Docs.Contents)
-		}
-		file.PackageDocs = b.String()
+	// Write WIT file for this world
+	witFile := g.witFileFor(w)
+	witFile.WriteString(g.res.WIT(w, ""))
+
+	// Write Go package docs
+	file := g.fileFor(w)
+	var b strings.Builder
+	stringio.Write(&b, "Package ", pkg.Name, " represents the ", w.WITKind(), " \"", g.moduleNames[w], "\".\n")
+	if w.Docs.Contents != "" {
+		b.WriteString("\n")
+		b.WriteString(w.Docs.Contents)
 	}
+	file.PackageDocs = b.String()
 
 	w.Imports.All()(func(name string, v wit.WorldItem) bool {
 		switch v := v.(type) {
@@ -2163,6 +2166,12 @@ func (g *generator) fileFor(owner wit.TypeOwner) *gen.File {
 	pkg := g.packageFor(owner)
 	file := pkg.File(path.Base(pkg.Path) + ".wit.go")
 	file.GeneratedBy = g.opts.generatedBy
+	return file
+}
+
+func (g *generator) witFileFor(owner wit.TypeOwner) *gen.File {
+	pkg := g.packageFor(owner)
+	file := pkg.File(path.Base(pkg.Path) + ".wit")
 	return file
 }
 

--- a/wit/bindgen/testdata_test.go
+++ b/wit/bindgen/testdata_test.go
@@ -170,7 +170,7 @@ func validateGeneratedGo(t *testing.T, res *wit.Resolve, origin string) {
 		}
 
 		// Verify number of files
-		count := len(goPkg.OtherFiles)
+		count := len(goPkg.OtherFiles) + len(goPkg.IgnoredFiles)
 		// t.Logf("Go package: %s %t", goPkg.PkgPath, goPkg.Types.Complete())
 		for _, f := range goPkg.GoFiles {
 			count++
@@ -180,9 +180,9 @@ func validateGeneratedGo(t *testing.T, res *wit.Resolve, origin string) {
 				t.Errorf("unknown file in package %s: %s", pkg.Path, base)
 			}
 		}
-		if count < len(pkg.Files) {
-			t.Errorf("%d files in package %s; expected %d:\n%s", count, pkg.Path, len(pkg.Files),
-				strings.Join(append(goPkg.GoFiles, goPkg.OtherFiles...), "\n"))
+		if count > len(pkg.Files) {
+			t.Errorf("%d files in package %s (expected %d):\n%s", count, pkg.Path, len(pkg.Files),
+				strings.Join(append(append(goPkg.GoFiles, goPkg.OtherFiles...), goPkg.IgnoredFiles...), "\n"))
 		}
 
 		// Verify generated names

--- a/wit/bindgen/testdata_test.go
+++ b/wit/bindgen/testdata_test.go
@@ -107,6 +107,7 @@ func validateGeneratedGo(t *testing.T, res *wit.Resolve, origin string) {
 	pkgs, err := Go(res,
 		GeneratedBy("test"),
 		PackageRoot(pkgPath),
+		Versioned(true),
 	)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
This is a step towards embedding textual WIT in a WebAssembly module generated by TinyGo (and eventually Go), for consumption by downstream programs like `wasm-tools` or for use as runtime metadata.

This can be verified by running `go test ./wit/bindgen -write` and examining the contents of the `generated` directory.

Inspired by #179.