### PR TITLE
wit/bindgen: tidy up .wasm.go file generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Go [type aliases](https://go.dev/ref/spec#Alias_declarations) are now generated for each WIT type alias (`type foo = bar`). Deep chains of type aliases (`type b = a; type c = b;`) are fully supported. Generated documentation now reflects whether a type is an alias. Fixes [#204](https://github.com/bytecodealliance/wasm-tools-go/issues/204).
+- `go:wasmimport` and `go:wasmexport` functions are now generated in a separate `.wasm.go` file. This helps enable testing or use of generated packages outside of WebAssembly.
 - `wit-bindgen-go wit` now accepts a `--world` argument in the form of `imports`, `wasi:clocks/imports`, or `wasi:clocks/imports@0.2.0`. This filters the serialized WIT to a specific world and interfaces it references. This can be used to generate focused WIT for a specific world with a minimal set of dependencies.
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,12 @@ $(wit_files):
 .PHONY: golden
 golden: json
 	go test ./wit -update
+
+# generated writes test Go code to the filesystem
+.PHONY: generated
+generated: clean
+	go test ./wit/bindgen -write
+
+.PHONY: clean
+clean:
+	rm -rf ./generated/*

--- a/wit/bindgen/generator.go
+++ b/wit/bindgen/generator.go
@@ -812,9 +812,11 @@ func (g *generator) variantRep(file *gen.File, dir wit.Direction, v *wit.Variant
 	shape := variantShape(v.Types())
 	align := variantAlign(v.Types())
 
-	typeShape := g.typeShape(file, dir, shape)
+	var typeShape string
 	if len(v.Types()) == 1 {
 		typeShape = g.typeRep(file, dir, shape)
+	} else {
+		typeShape = g.typeShape(file, dir, shape)
 	}
 
 	scope := gen.NewScope(file)
@@ -880,10 +882,12 @@ func (g *generator) variantRep(file *gen.File, dir wit.Direction, v *wit.Variant
 }
 
 func (g *generator) resultRep(file *gen.File, dir wit.Direction, r *wit.Result) string {
+	var typeShape string
 	shape := variantShape(r.Types())
-	typeShape := g.typeShape(file, dir, shape)
 	if len(r.Types()) == 1 {
 		typeShape = g.typeRep(file, dir, shape)
+	} else {
+		typeShape = g.typeShape(file, dir, shape)
 	}
 
 	// Emit type
@@ -936,7 +940,7 @@ func (g *generator) typeShape(file *gen.File, dir wit.Direction, t wit.Type) str
 
 	switch t := t.(type) {
 	case *wit.TypeDef:
-		t = t.Root()
+		// t = t.Root()
 		return g.typeDefShape(file, dir, t)
 	default:
 		return g.typeRep(file, dir, t)


### PR DESCRIPTION
This fixes two subtle bugs where creating a shape type for `result` or `variant` types used in a `wasmimport` function could have a side-effect of importing an unused Go package into the `.wasm.go` file, which would cause the generated Go to fail.

It should be reviewed commit by commit.

This is a follow up to #194.